### PR TITLE
Flake hosts

### DIFF
--- a/modules/clusters/uff/modules/k3s.nix
+++ b/modules/clusters/uff/modules/k3s.nix
@@ -1,11 +1,12 @@
 {config, ...}: let
-  inherit (config.flake.modules) nixos;
+  inherit (config.flake) modules hosts;
 in {
   flake.modules.nixos.uff = {config, ...}: let
     inherit (builtins) head;
+    # This IP is the locally evaluated host's
     enusb = (head config.networking.interfaces.enusb1.ipv4.addresses).address;
   in {
-    imports = with nixos; [
+    imports = with modules.nixos; [
       k3s
       kube-longhorn
     ];
@@ -17,7 +18,7 @@ in {
         "--node-name ${config.networking.hostName}s"
         "--node-ip ${enusb}"
         "--advertise-address ${enusb}"
-        "--server https://192.168.61.145:6443" # Serves as the bootstrapper
+        "--server https://${hosts.uff1.interfaces.enusb1.ipv4}:6443" # Serves as the bootstrapper
       ];
     };
   };

--- a/modules/clusters/uff/modules/network/interfaces.nix
+++ b/modules/clusters/uff/modules/network/interfaces.nix
@@ -1,10 +1,28 @@
-{
-  flake.modules.nixos.uff = {config, ...}: {
+{config, ...}: let
+  inherit (config.flake) hosts;
+in {
+  flake.modules.nixos.uff = {config, ...}: let
+    inherit (hosts.${config.networking.hostName}.interfaces) lo eno1 enusb1;
+  in {
     networking.interfaces = {
-      enusb1.mtu = 9000;
+      enusb1 = {
+        mtu = 9000;
+        ipv4.addresses = [
+          {
+            address = enusb1.ipv4;
+            prefixLength = 28;
+          }
+        ];
+      };
+      eno1.ipv4.addresses = [
+        {
+          address = eno1.ipv4;
+          prefixLength = 24;
+        }
+      ];
       lo.ipv4.addresses = [
         {
-          address = config.networking.loopback.ipv4;
+          address = lo.ipv4;
           prefixLength = 32;
         }
         {

--- a/modules/clusters/uff/modules/network/routing.nix
+++ b/modules/clusters/uff/modules/network/routing.nix
@@ -15,7 +15,7 @@ in {
     neighbors =
       concatMapStringsSep "\n" (
         n: "neighbor ${n} peer-group fabric"
-      ) (filter (n: n != lo) [
+      ) (filter (n: n != lo.ipv4) [
         # UFFs
         uff1.interfaces.lo.ipv4
         uff2.interfaces.lo.ipv4
@@ -28,7 +28,7 @@ in {
         n: "peer ${n}"
       ) (filter (
           n:
-            !(hasPrefix n eno1.ipv4) && !(hasPrefix n enusb1.ipv4)
+            !(hasPrefix eno1.ipv4 n) && !(hasPrefix enusb1.ipv4 n)
         ) [
           # UFF interfaces
           uff1.interfaces.eno1.ipv4

--- a/modules/clusters/uff/modules/network/routing.nix
+++ b/modules/clusters/uff/modules/network/routing.nix
@@ -1,15 +1,15 @@
-{
+{config, ...}: let
+  inherit (config.flake) hosts;
+  inherit (hosts) uff1 uff2 uff3;
+in {
   flake.modules.nixos.uff = {
     config,
     lib,
     ...
   }: let
-    inherit (builtins) head;
     inherit (lib) filter hasPrefix;
     inherit (lib.strings) concatMapStringsSep;
-    lo = config.networking.loopback.ipv4;
-    eno1 = (head config.networking.interfaces.eno1.ipv4.addresses).address;
-    enusb1 = (head config.networking.interfaces.enusb1.ipv4.addresses).address;
+    inherit (hosts.${config.networking.hostName}.interfaces) lo eno1 enusb1;
 
     # Exclude the current host from the neighbors
     neighbors =
@@ -17,9 +17,9 @@
         n: "neighbor ${n} peer-group fabric"
       ) (filter (n: n != lo) [
         # UFFs
-        "192.168.61.1"
-        "192.168.61.2"
-        "192.168.61.3"
+        uff1.interfaces.lo.ipv4
+        uff2.interfaces.lo.ipv4
+        uff3.interfaces.lo.ipv4
       ]);
 
     # exclude current host from BFD peers
@@ -28,19 +28,20 @@
         n: "peer ${n}"
       ) (filter (
           n:
-            !(hasPrefix n eno1) && !(hasPrefix n enusb1)
+            !(hasPrefix n eno1.ipv4) && !(hasPrefix n enusb1.ipv4)
         ) [
           # UFF interfaces
-          "192.168.49.31"
-          "192.168.49.32"
-          "192.168.49.33"
-          "192.168.61.145"
-          "192.168.61.146"
-          "192.168.61.147"
+          uff1.interfaces.eno1.ipv4
+          uff1.interfaces.enusb1.ipv4
+          uff2.interfaces.eno1.ipv4
+          uff2.interfaces.enusb1.ipv4
+          uff3.interfaces.eno1.ipv4
+          uff3.interfaces.enusb1.ipv4
 
           # Other Hosts
+          hosts.x570.interfaces.enp6s0.ipv4
+          hosts.x570.interfaces.enp7s0.ipv4
           "192.168.49.2" # Cisco
-          "192.168.49.10" # X570
         ]);
   in {
     networking = {
@@ -64,7 +65,7 @@
         ipv6 forwarding
         !
         router ospf
-         router-id ${lo}
+         router-id ${lo.ipv4}
         int lo
          ip ospf area 0
          ip ospf passive
@@ -81,15 +82,15 @@
          ip ospf cost 1000
         !
         router bgp 65101
-         bgp router-id ${lo}
+         bgp router-id ${lo.ipv4}
          no bgp default ipv4-unicast
 
          neighbor fabric peer-group
-         neighbor fabric update-source ${lo}
+         neighbor fabric update-source ${lo.ipv4}
          neighbor fabric remote-as 65101
          ${neighbors}
-         neighbor 192.168.48.1 remote-as 65101
-         neighbor 192.168.48.1 bfd
+         neighbor 192.168.49.1 remote-as 65101
+         neighbor 192.168.49.1 bfd
 
          address-family l2vpn evpn
           neighbor fabric activate
@@ -97,15 +98,15 @@
          exit-address-family
 
          address-family ipv4 unicast
-          neighbor 192.168.48.1 prefix-list MT3 in
-          neighbor 192.168.48.1 activate
+          neighbor 192.168.49.1 prefix-list MT3 in
+          neighbor 192.168.49.1 activate
 
          exit-address-family
         exit
         !
         bfd
          ${bfdPeers}
-         peer 192.168.48.1
+         peer 192.168.49.1
           transmit-interval 1000
           receive-interval 2000
       '';

--- a/modules/clusters/uff/uff1/network.nix
+++ b/modules/clusters/uff/uff1/network.nix
@@ -1,17 +1,19 @@
-{
+{config, ...}: let
+  inherit (config.flake.hosts.uff1.interfaces) lo eno1 enusb1;
+in {
   flake.modules.nixos.uff1 = {
     custom.enusb1.mac = "6c:1f:f7:06:27:8e";
     networking = {
       interfaces = {
         enusb1.ipv4.addresses = [
           {
-            address = "192.168.61.145";
+            address = enusb1.ipv4;
             prefixLength = 28;
           }
         ];
         eno1.ipv4.addresses = [
           {
-            address = "192.168.49.31";
+            address = eno1.ipv4;
             prefixLength = 24;
           }
         ];
@@ -28,7 +30,7 @@
         };
       };
 
-      loopback.ipv4 = "192.168.61.1";
+      loopback.ipv4 = lo.ipv4;
       hostId = "ab0406ca";
       hostName = "uff1";
 

--- a/modules/clusters/uff/uff1/network.nix
+++ b/modules/clusters/uff/uff1/network.nix
@@ -1,24 +1,7 @@
-{config, ...}: let
-  inherit (config.flake.hosts.uff1.interfaces) lo eno1 enusb1;
-in {
+{
   flake.modules.nixos.uff1 = {
     custom.enusb1.mac = "6c:1f:f7:06:27:8e";
     networking = {
-      interfaces = {
-        enusb1.ipv4.addresses = [
-          {
-            address = enusb1.ipv4;
-            prefixLength = 28;
-          }
-        ];
-        eno1.ipv4.addresses = [
-          {
-            address = eno1.ipv4;
-            prefixLength = 24;
-          }
-        ];
-      };
-
       networkmanager.ensureProfiles.profiles = {
         home = {
           ipv4.address = "172.16.248.31/16";
@@ -30,7 +13,6 @@ in {
         };
       };
 
-      loopback.ipv4 = lo.ipv4;
       hostId = "ab0406ca";
       hostName = "uff1";
 

--- a/modules/clusters/uff/uff2/network.nix
+++ b/modules/clusters/uff/uff2/network.nix
@@ -1,24 +1,7 @@
-{config, ...}: let
-  inherit (config.flake.hosts.uff2.interfaces) lo eno1 enusb1;
-in {
+{
   flake.modules.nixos.uff2 = {
     custom.enusb1.mac = "6c:1f:f7:06:27:ae";
     networking = {
-      interfaces = {
-        enusb1.ipv4.addresses = [
-          {
-            address = enusb1.ipv4;
-            prefixLength = 28;
-          }
-        ];
-        eno1.ipv4.addresses = [
-          {
-            address = eno1.ipv4;
-            prefixLength = 24;
-          }
-        ];
-      };
-
       networkmanager.ensureProfiles.profiles = {
         home = {
           ipv4.address = "172.16.248.32/16";
@@ -30,7 +13,6 @@ in {
         };
       };
 
-      loopback.ipv4 = lo.ipv4;
       hostId = "072294f5";
       hostName = "uff2";
 

--- a/modules/clusters/uff/uff2/network.nix
+++ b/modules/clusters/uff/uff2/network.nix
@@ -1,17 +1,19 @@
-{
+{config, ...}: let
+  inherit (config.flake.hosts.uff2.interfaces) lo eno1 enusb1;
+in {
   flake.modules.nixos.uff2 = {
     custom.enusb1.mac = "6c:1f:f7:06:27:ae";
     networking = {
       interfaces = {
         enusb1.ipv4.addresses = [
           {
-            address = "192.168.61.146";
+            address = enusb1.ipv4;
             prefixLength = 28;
           }
         ];
         eno1.ipv4.addresses = [
           {
-            address = "192.168.49.32";
+            address = eno1.ipv4;
             prefixLength = 24;
           }
         ];
@@ -28,7 +30,7 @@
         };
       };
 
-      loopback.ipv4 = "192.168.61.2";
+      loopback.ipv4 = lo.ipv4;
       hostId = "072294f5";
       hostName = "uff2";
 

--- a/modules/clusters/uff/uff3/network.nix
+++ b/modules/clusters/uff/uff3/network.nix
@@ -1,17 +1,19 @@
-{
+{config, ...}: let
+  inherit (config.flake.hosts.uff3.interfaces) lo eno1 enusb1;
+in {
   flake.modules.nixos.uff3 = {
     custom.enusb1.mac = "6c:1f:f7:06:13:8f";
     networking = {
       interfaces = {
         enusb1.ipv4.addresses = [
           {
-            address = "192.168.61.147";
+            address = enusb1.ipv4;
             prefixLength = 28;
           }
         ];
         eno1.ipv4.addresses = [
           {
-            address = "192.168.49.33";
+            address = eno1.ipv4;
             prefixLength = 24;
           }
         ];
@@ -28,7 +30,7 @@
         };
       };
 
-      loopback.ipv4 = "192.168.61.3";
+      loopback.ipv4 = lo.ipv4;
       hostId = "f303a8e8";
       hostName = "uff3";
 

--- a/modules/clusters/uff/uff3/network.nix
+++ b/modules/clusters/uff/uff3/network.nix
@@ -1,24 +1,7 @@
-{config, ...}: let
-  inherit (config.flake.hosts.uff3.interfaces) lo eno1 enusb1;
-in {
+{
   flake.modules.nixos.uff3 = {
     custom.enusb1.mac = "6c:1f:f7:06:13:8f";
     networking = {
-      interfaces = {
-        enusb1.ipv4.addresses = [
-          {
-            address = enusb1.ipv4;
-            prefixLength = 28;
-          }
-        ];
-        eno1.ipv4.addresses = [
-          {
-            address = eno1.ipv4;
-            prefixLength = 24;
-          }
-        ];
-      };
-
       networkmanager.ensureProfiles.profiles = {
         home = {
           ipv4.address = "172.16.248.33/16";
@@ -30,7 +13,6 @@ in {
         };
       };
 
-      loopback.ipv4 = lo.ipv4;
       hostId = "f303a8e8";
       hostName = "uff3";
 

--- a/modules/flake/hostOptions.nix
+++ b/modules/flake/hostOptions.nix
@@ -1,7 +1,7 @@
 # Options used in NixOS hosts
 {lib, ...}: let
   inherit (lib) mkOption;
-  inherit (lib.types) enum;
+  inherit (lib.types) enum str nullOr attrsOf submodule listOf;
 in {
   options.host = {
     bootloader = mkOption {
@@ -9,6 +9,40 @@ in {
       type = enum ["systemd-boot" "grub" "limine" "none"];
       default = "systemd-boot";
       description = "Which bootloader flake module to use with the host.";
+    };
+
+    hosts = mkOption {
+      type = attrsOf (submodule {
+        options = {
+          aliases = mkOption {
+            type = listOf str;
+            default = [];
+            description = "Additional hostnames/aliases for this host.";
+          };
+
+          interfaces = mkOption {
+            type = attrsOf (submodule {
+              options = {
+                ipv4 = mkOption {
+                  type = nullOr str;
+                  default = null;
+                  description = "IPv4 address for this interface.";
+                };
+
+                ipv6 = mkOption {
+                  type = nullOr str;
+                  default = null;
+                  description = "IPv6 address for this interface.";
+                };
+              };
+            });
+            default = {};
+            description = "Interface-specific IP addresses.";
+          };
+        };
+      });
+      default = {};
+      description = "Host IP mappings for hosts file generation and routing configuration.";
     };
   };
 }

--- a/modules/flake/hostOptions.nix
+++ b/modules/flake/hostOptions.nix
@@ -3,12 +3,14 @@
   inherit (lib) mkOption;
   inherit (lib.types) enum str nullOr attrsOf submodule listOf;
 in {
-  options.host = {
-    bootloader = mkOption {
-      # None is used in special circumstances like WSL
-      type = enum ["systemd-boot" "grub" "limine" "none"];
-      default = "systemd-boot";
-      description = "Which bootloader flake module to use with the host.";
+  options = {
+    host = {
+      bootloader = mkOption {
+        # None is used in special circumstances like WSL
+        type = enum ["systemd-boot" "grub" "limine" "none"];
+        default = "systemd-boot";
+        description = "Which bootloader flake module to use with the host.";
+      };
     };
 
     hosts = mkOption {

--- a/modules/flake/hosts.nix
+++ b/modules/flake/hosts.nix
@@ -1,5 +1,5 @@
 # Host IP definitions for hosts file generation and routing configs
-# These are reused anywhere the IPs need to referenced and serve
+# These are reused anywhere the IPs need to be referenced and serve
 # as the single source of truth
 {
   flake.hosts = {
@@ -45,15 +45,15 @@
     };
 
     t14.interfaces = {
-      lo.ipv4 = "";
+      lo.ipv4 = null;
     };
 
     o1.interfaces = {
-      lo.ipv4 = "";
+      lo.ipv4 = null;
     };
 
     tempest.interfaces = {
-      lo.ipv4 = "";
+      lo.ipv4 = null;
     };
   };
 }

--- a/modules/flake/hosts.nix
+++ b/modules/flake/hosts.nix
@@ -43,5 +43,17 @@
       #enp15s0f1.ipv4 = ""; # Not currently used
       wlp5s0.ipv4 = "172.16.248.10";
     };
+
+    t14.interfaces = {
+      lo.ipv4 = "";
+    };
+
+    o1.interfaces = {
+      lo.ipv4 = "";
+    };
+
+    tempest.interfaces = {
+      lo.ipv4 = "";
+    };
   };
 }

--- a/modules/flake/hosts.nix
+++ b/modules/flake/hosts.nix
@@ -1,0 +1,47 @@
+# Host IP definitions for hosts file generation and routing configs
+# These are reused anywhere the IPs need to referenced and serve
+# as the single source of truth
+{
+  flake.hosts = {
+    # UFF Cluster
+    uff1 = {
+      interfaces = {
+        lo.ipv4 = "192.168.61.1";
+        enusb1.ipv4 = "192.168.61.145";
+        eno1.ipv4 = "192.168.49.31";
+      };
+    };
+
+    uff2 = {
+      interfaces = {
+        lo.ipv4 = "192.168.61.2";
+        enusb1.ipv4 = "192.168.61.146";
+        eno1.ipv4 = "192.168.49.32";
+      };
+    };
+
+    uff3 = {
+      interfaces = {
+        lo.ipv4 = "192.168.61.3";
+        enusb1.ipv4 = "192.168.61.147";
+        eno1.ipv4 = "192.168.49.33";
+      };
+    };
+
+    p520.interfaces = {
+      lo.ipv4 = "192.168.63.5";
+      br0.ipv4 = "192.168.49.5";
+      ens1f0.ipv4 = "192.168.61.130";
+      ens1f1.ipv4 = "192.168.61.131";
+    };
+
+    x570.interfaces = {
+      lo.ipv4 = "192.168.63.10";
+      enp6s0.ipv4 = "192.168.49.10";
+      enp7s0.ipv4 = "192.168.61.149";
+      enp15s0f0.ipv4 = "192.168.61.129";
+      #enp15s0f1.ipv4 = ""; # Not currently used
+      wlp5s0.ipv4 = "172.16.248.10";
+    };
+  };
+}

--- a/modules/hosts/p520/networking/default.nix
+++ b/modules/hosts/p520/networking/default.nix
@@ -26,8 +26,6 @@ in {
         interface = "br0";
       };
 
-      loopback.ipv4 = interfaces.lo.ipv4;
-
       firewall.trustedInterfaces = ["br0"];
 
       bridges = {

--- a/modules/hosts/p520/networking/default.nix
+++ b/modules/hosts/p520/networking/default.nix
@@ -1,4 +1,6 @@
-{
+{config, ...}: let
+  inherit (config.flake.hosts.p520) interfaces;
+in {
   flake.modules.nixos.p520 = {
     services = {
       iperf3.enable = true;
@@ -24,7 +26,7 @@
         interface = "br0";
       };
 
-      loopback.ipv4 = "192.168.63.5";
+      loopback.ipv4 = interfaces.lo.ipv4;
 
       firewall.trustedInterfaces = ["br0"];
 
@@ -34,7 +36,7 @@
       interfaces = {
         br0.ipv4.addresses = [
           {
-            address = "192.168.49.5";
+            address = interfaces.br0.ipv4;
             prefixLength = 24;
           }
         ];
@@ -42,7 +44,7 @@
           mtu = 9000;
           ipv4.addresses = [
             {
-              address = "192.168.61.130";
+              address = interfaces.ens1f0.ipv4;
               prefixLength = 28;
             }
           ];
@@ -51,7 +53,7 @@
           mtu = 9000;
           ipv4.addresses = [
             {
-              address = "192.168.61.131";
+              address = interfaces.ens1f1.ipv4;
               prefixLength = 28;
             }
           ];

--- a/modules/hosts/x570/networking/default.nix
+++ b/modules/hosts/x570/networking/default.nix
@@ -1,4 +1,6 @@
-{
+{config, ...}: let
+  inherit (config.flake.hosts.x570) interfaces;
+in {
   flake.modules.nixos.x570 = {
     services = {
       iperf3.enable = true;
@@ -37,7 +39,7 @@
       interfaces = {
         enp6s0.ipv4.addresses = [
           {
-            address = "192.168.49.10";
+            address = interfaces.enp6s0.ipv4;
             prefixLength = 24;
           }
         ];
@@ -45,7 +47,7 @@
           mtu = 9000;
           ipv4.addresses = [
             {
-              address = "192.168.61.149";
+              address = interfaces.enp7s0.ipv4;
               prefixLength = 28;
             }
           ];
@@ -54,14 +56,14 @@
           mtu = 9000;
           ipv4.addresses = [
             {
-              address = "192.168.61.129";
+              address = interfaces.enp15s0f0.ipv4;
               prefixLength = 28;
             }
           ];
         };
         lo.ipv4.addresses = [
           {
-            address = "192.168.63.10";
+            address = interfaces.lo.ipv4;
             prefixLength = 32;
           }
         ];

--- a/modules/hosts/x570/networking/routing.nix
+++ b/modules/hosts/x570/networking/routing.nix
@@ -1,8 +1,7 @@
-{
-  flake.modules.nixos.x570 = {config, ...}: let
-    inherit (builtins) head getAttr;
-    lo = getAttr "address" (head config.networking.interfaces.lo.ipv4.addresses);
-  in {
+{config, ...}: let
+  inherit (config.flake.hosts.x570.interfaces) lo;
+in {
+  flake.modules.nixos.x570 = {
     # Default Nixos will have standard priority, force to override
     # environment.etc."frr/frr.conf".source = lib.mkForce config.age.secrets.frr.path;
 
@@ -12,18 +11,18 @@
 
       ip prefix-list 64800-IN seq 5 permit 192.168.64.0/20
       ip prefix-list 64800-IN seq 10 deny 0.0.0.0/0
-      ip prefix-list 64800-OUT seq 5 permit ${lo}
+      ip prefix-list 64800-OUT seq 5 permit ${lo.ipv4}
       ip prefix-list 64800-OUT seq 10 deny 0.0.0.0/0
 
       router ospf
-        router-id ${lo}
+        router-id ${lo.ipv4}
 
       router bgp 65100
         no bgp ebgp-requires-policy
         neighbor 192.168.240.241 remote-as 64800
 
         address-family ipv4
-          network ${lo}/32
+          network ${lo.ipv4}/32
           neighbor 192.168.240.241 activate
         exit
 
@@ -42,11 +41,6 @@
       int enp15s0f0
         ip ospf cost 100
         ip ospf area 0
-
-      bfd
-       peer 192.168.48.31
-       peer 192.168.48.32
-       peer 192.168.48.33
     '';
 
     networking = {

--- a/modules/nixos/network/default.nix
+++ b/modules/nixos/network/default.nix
@@ -39,7 +39,7 @@ in {
       };
 
       # Apply the loopback address if added
-      networking.interfaces.lo.ipv4.addresses = lib.optionals (lo.ipv4 != null || lo.ipv4 != "") [
+      networking.interfaces.lo.ipv4.addresses = lib.optionals (lo.ipv4 != null) [
         {
           address = lo.ipv4;
           prefixLength = 32;

--- a/modules/nixos/network/hosts.nix
+++ b/modules/nixos/network/hosts.nix
@@ -1,4 +1,6 @@
-{
+{config, ...}: let
+  inherit (config.flake) hosts;
+in {
   flake.modules.nixos.network = {
     networking.hosts = {
       "192.168.48.1" = ["mt3" "mt3.michael.lan"];
@@ -6,24 +8,25 @@
       "192.168.48.3" = ["r8200" "r8200.michael.lan"];
 
       "192.168.48.20" = ["m1" "m1.michael.lan"];
-      "192.168.63.10" = ["x570" "x570.michael.lan"];
+      "${hosts.x570.interfaces.lo.ipv4}" = ["x570" "x570.michael.lan"];
 
-      "192.168.63.5" = ["p520" "p520.michael.lan"];
-      "192.168.49.5" = [
+      "${hosts.p520.interfaces.lo.ipv4}" = [
+        "p520"
+        "p520.michael.lan"
         "git.p520.michael.lan"
         "owi.p520.michael.lan"
       ];
 
       # 2.5GbE
-      "192.168.61.145" = ["uff1s"];
-      "192.168.61.146" = ["uff2s"];
-      "192.168.61.147" = ["uff3s"];
+      "${hosts.uff1.interfaces.enusb1.ipv4}" = ["uff1s"];
+      "${hosts.uff2.interfaces.enusb1.ipv4}" = ["uff2s"];
+      "${hosts.uff3.interfaces.enusb1.ipv4}" = ["uff3s"];
 
       # Loopbacks
       "192.168.61.0" = ["uff" "uff.michael.lan"];
-      "192.168.61.1" = ["uff1" "uff1.michael.lan"];
-      "192.168.61.2" = ["uff2" "uff2.michael.lan"];
-      "192.168.61.3" = ["uff3" "uff3.michael.lan"];
+      "${hosts.uff1.interfaces.lo.ipv4}" = ["uff1" "uff1.michael.lan"];
+      "${hosts.uff2.interfaces.lo.ipv4}" = ["uff2" "uff2.michael.lan"];
+      "${hosts.uff3.interfaces.lo.ipv4}" = ["uff3" "uff3.michael.lan"];
     };
   };
 }

--- a/modules/nixos/network/ospf.nix
+++ b/modules/nixos/network/ospf.nix
@@ -1,10 +1,13 @@
-{
+{config, ...}: let
+  inherit (config.flake) hosts;
+in {
   flake.modules.nixos.ospf = {
     config,
     lib,
     ...
   }: let
-    inherit (config.networking) ospf loopback;
+    inherit (config.networking) ospf hostName;
+    inherit (hosts.${hostName}.interfaces) lo;
 
     originate =
       if ospf.defaultRoute.metric != null
@@ -12,8 +15,8 @@
       else "";
 
     routerId =
-      if loopback.ipv4 != null
-      then "router-id ${loopback.ipv4}\n"
+      if lo.ipv4 != null
+      then "router-id ${lo.ipv4}\n"
       else "";
   in {
     options.networking.ospf = {


### PR DESCRIPTION
Convert static references to a single source of truth at the flake level, containing host IPs.  Used in various references like the `/etc/hosts` file and routing configs.