### PR TITLE
Custom outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,8 +28,7 @@
 
       # Easy mechanism to make them available everywhere
       flake = {
-        inherit mkImport npins;
-        nvfetcher = ./_sources/generated.nix;
+        inherit npins;
       };
 
       perSystem = {
@@ -38,6 +37,8 @@
         ...
       }: {
         _module.args = {
+          # Nvfetcher is only used for packaging so pass it as a module arg
+          nvfetcher = ./_sources/generated.nix;
           # Globally set unfree for all per-system evals
           pkgs = import nixpkgs {
             inherit system;

--- a/legacy/user/dolphin.nix
+++ b/legacy/user/dolphin.nix
@@ -1,5 +1,5 @@
 {
-  flake.hjemConfigs.dolphin = {pkgs, ...}: {
+  flake.custom.hjemConfigs.dolphin = {pkgs, ...}: {
     hjem.users.michael = {
       packages = with pkgs.kdePackages; [
         dolphin

--- a/legacy/user/termfilechooser.nix
+++ b/legacy/user/termfilechooser.nix
@@ -1,5 +1,5 @@
 {
-  flake.hjemConfigs.termfilechooser = {
+  flake.custom.hjemConfigs.termfilechooser = {
     config,
     pkgs,
     ...

--- a/modules/clusters/uff/modules/k3s.nix
+++ b/modules/clusters/uff/modules/k3s.nix
@@ -1,6 +1,6 @@
 {config, ...}: let
   inherit (config.flake) modules hosts;
-  inherit (config.flake.lib.network) getAddress;
+  inherit (config.flake.custom.lib.network) getAddress;
 in {
   flake.modules.nixos.uff = {
     config,

--- a/modules/clusters/uff/modules/k3s.nix
+++ b/modules/clusters/uff/modules/k3s.nix
@@ -1,5 +1,6 @@
 {config, ...}: let
-  inherit (config.flake) modules hosts;
+  inherit (config.flake) modules;
+  inherit (config.flake.custom) hosts;
   inherit (config.flake.custom.lib.network) getAddress;
 in {
   flake.modules.nixos.uff = {

--- a/modules/clusters/uff/modules/network/default.nix
+++ b/modules/clusters/uff/modules/network/default.nix
@@ -3,7 +3,7 @@
 in {
   flake.modules.nixos.uff = {config, ...}: let
     inherit (config.networking) hostName;
-    lo = flake.lib.network.getAddress flake.hosts.${hostName}.interfaces.lo.ipv4;
+    lo = flake.custom.lib.network.getAddress flake.hosts.${hostName}.interfaces.lo.ipv4;
   in {
     imports = with flake.modules.nixos; [
       lab-network

--- a/modules/clusters/uff/modules/network/default.nix
+++ b/modules/clusters/uff/modules/network/default.nix
@@ -3,7 +3,7 @@
 in {
   flake.modules.nixos.uff = {config, ...}: let
     inherit (config.networking) hostName;
-    lo = flake.custom.lib.network.getAddress flake.hosts.${hostName}.interfaces.lo.ipv4;
+    lo = flake.custom.lib.network.getAddress flake.custom.hosts.${hostName}.interfaces.lo.ipv4;
   in {
     imports = with flake.modules.nixos; [
       lab-network

--- a/modules/flake/flakeOptions.nix
+++ b/modules/flake/flakeOptions.nix
@@ -3,41 +3,43 @@
   inherit (lib.types) attrsOf deferredModule lazyAttrsOf raw;
 in {
   options.flake = {
-    hjemModules = mkOption {
-      type = attrsOf deferredModule;
-      default = {};
-      description = "Hjem modules to be included in the hjem user configuration.";
-    };
-    hjemConfigs = mkOption {
-      type = attrsOf deferredModule;
-      default = {};
-      description = "Hjem configurations with specific options set, usually per-user.";
-    };
-    userModules = mkOption {
-      type = attrsOf raw;
-      default = {};
-      description = "User configuration modules that can be shared across module types.";
-    };
-    extraConfigs = mkOption {
-      type = attrsOf raw;
-      default = {};
-      description = "Small extra configs I want to be portable around the flake.";
-    };
-    lib = mkOption {
-      type = lazyAttrsOf raw;
-      default = {};
-      description = "Library components which are not dependent on `pkgs`.";
-    };
-    functions = mkOption {
-      type = lazyAttrsOf raw;
-      default = {};
-      description = "Library functions which require `pkgs` to be primed and loaded.";
-    };
-    packageLists = mkOption {
-      description = "Commonly reused package lists, they are lists of strings found in nixpkgs that will be transformed given `pkgs` reference.";
-    };
-    wrappers = mkOption {
-      description = "Modules that can be called to created wrapped packages from this flake.";
+    custom = {
+      hjemModules = mkOption {
+        type = attrsOf deferredModule;
+        default = {};
+        description = "Hjem modules to be included in the hjem user configuration.";
+      };
+      hjemConfigs = mkOption {
+        type = attrsOf deferredModule;
+        default = {};
+        description = "Hjem configurations with specific options set, usually per-user.";
+      };
+      userModules = mkOption {
+        type = attrsOf raw;
+        default = {};
+        description = "User configuration modules that can be shared across module types.";
+      };
+      extraConfigs = mkOption {
+        type = attrsOf raw;
+        default = {};
+        description = "Small extra configs I want to be portable around the flake.";
+      };
+      lib = mkOption {
+        type = lazyAttrsOf raw;
+        default = {};
+        description = "Library components which are not dependent on `pkgs`.";
+      };
+      functions = mkOption {
+        type = lazyAttrsOf raw;
+        default = {};
+        description = "Library functions which require `pkgs` to be primed and loaded.";
+      };
+      packageLists = mkOption {
+        description = "Commonly reused package lists, they are lists of strings found in nixpkgs that will be transformed given `pkgs` reference.";
+      };
+      wrappers = mkOption {
+        description = "Modules that can be called to created wrapped packages from this flake.";
+      };
     };
   };
 }

--- a/modules/flake/hosts.nix
+++ b/modules/flake/hosts.nix
@@ -2,7 +2,7 @@
 # These are reused anywhere the IPs need to be referenced and serve
 # as the single source of truth
 {
-  flake.hosts = {
+  flake.custom.hosts = {
     uff1.interfaces = {
       lo.ipv4 = "192.168.61.1/32";
       br1.ipv4 = "192.168.59.10/27";

--- a/modules/hjem/configs/bash.nix
+++ b/modules/hjem/configs/bash.nix
@@ -1,7 +1,7 @@
 {config, ...}: let
-  inherit (config.flake.userModules.bash) bashrc bashProfile;
+  inherit (config.flake.custom.userModules.bash) bashrc bashProfile;
 in {
-  flake.hjemConfigs.bash = {
+  flake.custom.hjemConfigs.bash = {
     hjem.users.michael = {
       files = {
         ".bashrc".source = bashrc;

--- a/modules/hjem/configs/cursor.nix
+++ b/modules/hjem/configs/cursor.nix
@@ -3,7 +3,7 @@
 {config, ...}: let
   inherit (config) flake;
 in {
-  flake.hjemConfigs.cursor = {
+  flake.custom.hjemConfigs.cursor = {
     pkgs,
     lib,
     ...

--- a/modules/hjem/configs/ghostty.nix
+++ b/modules/hjem/configs/ghostty.nix
@@ -1,8 +1,8 @@
 {config, ...}: {
-  flake.hjemConfigs.ghostty = {pkgs, ...}: {
+  flake.custom.hjemConfigs.ghostty = {pkgs, ...}: {
     # For linking my config, such as on Mac if using brew
     hjem.users.michael.xdg.config.files."ghostty/config" = {
-      source = config.flake.wrappers.mkGhosttyConfig {inherit pkgs;};
+      source = config.flake.custom.wrappers.mkGhosttyConfig {inherit pkgs;};
       type = "copy";
       permissions = "0644";
     };

--- a/modules/hjem/configs/helium.nix
+++ b/modules/hjem/configs/helium.nix
@@ -1,5 +1,5 @@
 {
-  flake.hjemConfigs.helium = {pkgs, ...}: {
+  flake.custom.hjemConfigs.helium = {pkgs, ...}: {
     # Just plumbs the necessary components for getting widevine working
     # Package is now part of my fullEnv package
     hjem.users.michael = {

--- a/modules/hjem/configs/nushell.nix
+++ b/modules/hjem/configs/nushell.nix
@@ -2,7 +2,7 @@
 # This exists to patch in any nixos common elements not available
 # in the wrapper directly
 {
-  flake.hjemConfigs.nushell = {
+  flake.custom.hjemConfigs.nushell = {
     config,
     lib,
     ...

--- a/modules/hjem/configs/oxwm.nix
+++ b/modules/hjem/configs/oxwm.nix
@@ -6,7 +6,7 @@
   inherit (config.flake) userModules;
 in {
   # Intake my user modules directory for OXWM and reproduce it
-  flake.hjemConfigs.oxwm = {
+  flake.custom.hjemConfigs.oxwm = {
     hjem.users.michael = {
       xdg.config.files =
         builtins.mapAttrs

--- a/modules/hjem/configs/qt.nix
+++ b/modules/hjem/configs/qt.nix
@@ -1,5 +1,5 @@
 {
-  flake.hjemConfigs.qt = {pkgs, ...}: {
+  flake.custom.hjemConfigs.qt = {pkgs, ...}: {
     hjem.users.michael = {
       environment.sessionVariables = {
         # These are also in Hyprland since shell environment is not part of

--- a/modules/hjem/configs/zed.nix
+++ b/modules/hjem/configs/zed.nix
@@ -2,9 +2,9 @@
 # so mutably link an initial state to prevent issues
 # with not being able to have them convert the config
 {config, ...}: {
-  flake.hjemConfigs.zed = {pkgs, ...}: {
+  flake.custom.hjemConfigs.zed = {pkgs, ...}: {
     hjem.users.michael.xdg.config.files."zed/settings.json" = {
-      source = config.flake.wrappers.mkZedConfig {inherit pkgs;};
+      source = config.flake.custom.wrappers.mkZedConfig {inherit pkgs;};
       type = "copy";
       permissions = "0644";
     };

--- a/modules/hjem/darwin.nix
+++ b/modules/hjem/darwin.nix
@@ -3,11 +3,11 @@
   inputs,
   ...
 }: {
-  flake.hjemConfigs.darwin = {pkgs, ...}: {
+  flake.custom.hjemConfigs.darwin = {pkgs, ...}: {
     imports = [
       inputs.hjem.darwinModules.default
-      config.flake.hjemConfigs.default
-      config.flake.hjemConfigs.zed
+      config.flake.custom.hjemConfigs.default
+      config.flake.custom.hjemConfigs.zed
     ];
 
     hjem.users.michael = {

--- a/modules/hjem/default.nix
+++ b/modules/hjem/default.nix
@@ -2,7 +2,7 @@
   inherit (config) flake;
   editor = "vim"; # vim on servers, nvim on full systems
 in {
-  flake.hjemConfigs.default = {
+  flake.custom.hjemConfigs.default = {
     pkgs,
     lib,
     ...
@@ -13,7 +13,7 @@ in {
       then "home"
       else "User";
   in {
-    imports = with flake.hjemConfigs; [
+    imports = with flake.custom.hjemConfigs; [
       bash
       nushell
     ];
@@ -23,7 +23,7 @@ in {
       linker = pkgs.smfh;
 
       # Pull in all my modules
-      extraModules = builtins.attrValues flake.hjemModules;
+      extraModules = builtins.attrValues flake.custom.hjemModules;
 
       users.michael = {
         environment.sessionVariables = {
@@ -38,8 +38,8 @@ in {
           NH_FLAKE = lib.mkDefault "/${home}/michael/nixos";
           IP_COLOR = "always";
           NIXPKGS_ALLOW_FREE = "1";
-          GIT_SIGNING_KEYS_FILE = flake.wrappers.mkGitSignersFile {inherit pkgs;};
-          GIT_CONFIG_GLOBAL = flake.wrappers.mkGitConfig {inherit pkgs;};
+          GIT_SIGNING_KEYS_FILE = flake.custom.wrappers.mkGitSignersFile {inherit pkgs;};
+          GIT_CONFIG_GLOBAL = flake.custom.wrappers.mkGitConfig {inherit pkgs;};
         };
       };
     };

--- a/modules/hjem/extended.nix
+++ b/modules/hjem/extended.nix
@@ -1,6 +1,6 @@
 {config, ...}: {
-  flake.hjemConfigs.extended = {pkgs, ...}: {
-    imports = with config.flake.hjemConfigs; [
+  flake.custom.hjemConfigs.extended = {pkgs, ...}: {
+    imports = with config.flake.custom.hjemConfigs; [
       cursor
       helium
       qt

--- a/modules/hjem/nixos.nix
+++ b/modules/hjem/nixos.nix
@@ -3,8 +3,8 @@
   inputs,
   ...
 }: {
-  flake.hjemConfigs.nixos.imports = [
+  flake.custom.hjemConfigs.nixos.imports = [
     inputs.hjem.nixosModules.default
-    config.flake.hjemConfigs.default
+    config.flake.custom.hjemConfigs.default
   ];
 }

--- a/modules/hjem/root.nix
+++ b/modules/hjem/root.nix
@@ -1,7 +1,7 @@
 # A basic Root user configuration that pulls in select aspects of my configs
 # *This does depend on importing my hjem configs
 {
-  flake.hjemConfigs.root = {config, ...}: let
+  flake.custom.hjemConfigs.root = {config, ...}: let
     inherit (config.users.users) michael shawn;
   in {
     users.users.root = {

--- a/modules/home/chimera/dinit/niri-session.nix
+++ b/modules/home/chimera/dinit/niri-session.nix
@@ -6,7 +6,7 @@
   }: let
     inherit (config.flake.packages.${pkgs.stdenv.hostPlatform.system}) noctalia;
 
-    session-vars = config.flake.extraConfigs.session-vars {inherit pkgs;};
+    session-vars = config.flake.custom.extraConfigs.session-vars {inherit pkgs;};
 
     sessionEnd = pkgs.writeShellScript "niri-session-end" ''
       if [ -p "$SESSION_PIPE" ]; then
@@ -22,9 +22,9 @@
       )
     );
 
-    niri = config.flake.wrappers.mkNiri {
+    niri = config.flake.custom.wrappers.mkNiri {
       inherit pkgs;
-      extraConfig = config.flake.extraConfigs.t14-niri;
+      extraConfig = config.flake.custom.extraConfigs.t14-niri;
       spawnNoctalia = false;
       systemd = false;
     };

--- a/modules/home/chimera/dinit/zed-deploy.nix
+++ b/modules/home/chimera/dinit/zed-deploy.nix
@@ -9,7 +9,7 @@
   file = "/home/michael/.config/zed/settings.json";
 in {
   flake.modules.homeManager.chimera-zed-deploy = {pkgs, ...}: let
-    cfg = config.flake.wrappers.mkZedConfig {inherit pkgs;};
+    cfg = config.flake.custom.wrappers.mkZedConfig {inherit pkgs;};
     wrapper = pkgs.writeShellScriptBin "zed-deploy-wrapper" ''
       # Skip if the config already exists
       if [ -e ${file} ]; then

--- a/modules/home/common/configs/bash.nix
+++ b/modules/home/common/configs/bash.nix
@@ -1,5 +1,5 @@
 {config, ...}: let
-  inherit (config.flake.userModules.bash) bashrc bashProfile;
+  inherit (config.flake.custom.userModules.bash) bashrc bashProfile;
 in {
   flake.modules.homeManager.bash = {pkgs, ...}: {
     home.file = {
@@ -15,7 +15,7 @@ in {
           alias fz='fzf --height 40% --reverse --border'
 
           export FZF_DEFAULT_COMMAND='fd --type f --hidden --follow --exclude .git'
-          export GIT_CONFIG_GLOBAL=${config.flake.wrappers.mkGitConfig {inherit pkgs;}}
+          export GIT_CONFIG_GLOBAL=${config.flake.custom.wrappers.mkGitConfig {inherit pkgs;}}
         '';
       ".config/bash/nushell".text =
         # bash

--- a/modules/home/common/files.nix
+++ b/modules/home/common/files.nix
@@ -2,6 +2,6 @@
   inherit (config) flake;
 in {
   flake.modules.homeManager.default = {pkgs, ...}: {
-    xdg.configFile."git/config".source = flake.wrappers.mkGitConfig {inherit pkgs;};
+    xdg.configFile."git/config".source = flake.custom.wrappers.mkGitConfig {inherit pkgs;};
   };
 }

--- a/modules/home/common/packages.nix
+++ b/modules/home/common/packages.nix
@@ -14,6 +14,6 @@ in {
   in {
     home.packages =
       localPkgs
-      ++ (functions.packageLists.combinePkgLists (with flake.packageLists; [cli development]));
+      ++ (functions.packageLists.combinePkgLists (with flake.custom.packageLists; [cli development]));
   };
 }

--- a/modules/hosts/t14/extraConfigs/session-vars.nix
+++ b/modules/hosts/t14/extraConfigs/session-vars.nix
@@ -3,7 +3,7 @@
 in {
   # Common Session Variables I reuse
   # Will require priming with pkgs to get the cursor path
-  flake.extraConfigs.session-vars = {pkgs}: let
+  flake.custom.extraConfigs.session-vars = {pkgs}: let
     inherit (pkgs.stdenv.hostPlatform) system;
   in {
     XCURSOR_PATH = "${packages.${system}.nordzy-cursor}/share/icons";

--- a/modules/hosts/t14/extraConfigs/t14-niri.nix
+++ b/modules/hosts/t14/extraConfigs/t14-niri.nix
@@ -1,7 +1,7 @@
 let
   mon1 = "eDP-1";
 in {
-  flake.extraConfigs.t14-niri = ''
+  flake.custom.extraConfigs.t14-niri = ''
     workspace "N1" { open-on-output "${mon1}"; }
     workspace "N2" { open-on-output "${mon1}"; }
     workspace "N3" { open-on-output "${mon1}"; }

--- a/modules/hosts/t14/user/hyprland.nix
+++ b/modules/hosts/t14/user/hyprland.nix
@@ -1,6 +1,6 @@
 {config, ...}: {
   flake.modules.nixos.t14 = {pkgs, ...}: {
-    hjem.users.michael.xdg.config.files."hypr/hyprland.conf".source = config.flake.wrappers.mkHyprlandConfig {
+    hjem.users.michael.xdg.config.files."hypr/hyprland.conf".source = config.flake.custom.wrappers.mkHyprlandConfig {
       inherit pkgs;
       hostConfig = pkgs.writeText "t14-hyprland-conf" ''
         # T14 Host-specific

--- a/modules/hosts/t14/user/niri.nix
+++ b/modules/hosts/t14/user/niri.nix
@@ -1,5 +1,5 @@
 {config, ...}: {
   flake.modules.nixos.t14 = {
-    custom.niri.extraConfig = config.flake.extraConfigs.t14-niri;
+    custom.niri.extraConfig = config.flake.custom.extraConfigs.t14-niri;
   };
 }

--- a/modules/hosts/x570/hyprland.nix
+++ b/modules/hosts/x570/hyprland.nix
@@ -3,7 +3,7 @@
   mon2 = "HDMI-A-3"; # Right side monitor, vertical 24"
 in {
   flake.modules.nixos.x570 = {pkgs, ...}: {
-    hjem.users.michael.xdg.config.files."hypr/hyprland.conf".source = config.flake.wrappers.mkHyprlandConfig {
+    hjem.users.michael.xdg.config.files."hypr/hyprland.conf".source = config.flake.custom.wrappers.mkHyprlandConfig {
       inherit pkgs;
       hostConfig = pkgs.writeText "x570-hyprland-conf" ''
         #X570 Host-Specific

--- a/modules/hosts/x570/networking/routing.nix
+++ b/modules/hosts/x570/networking/routing.nix
@@ -1,5 +1,5 @@
 {config, ...}: let
-  inherit (config.flake.lib.network) getAddress;
+  inherit (config.flake.custom.lib.network) getAddress;
   lo = getAddress config.flake.hosts.x570.interfaces.lo.ipv4;
 in {
   flake.modules.nixos.x570 = {

--- a/modules/lib/build_yaml.nix
+++ b/modules/lib/build_yaml.nix
@@ -1,5 +1,5 @@
 {
-  flake.functions.yaml = {pkgs}: {
+  flake.custom.functions.yaml = {pkgs}: {
     buildYAML = {
       attrs,
       name ? "built-yaml",

--- a/modules/lib/kube.nix
+++ b/modules/lib/kube.nix
@@ -1,5 +1,5 @@
 {
-  flake.functions.kube = {pkgs}: {
+  flake.custom.functions.kube = {pkgs}: {
     # Build a single manifest file from a kustomize directory
     buildManifest = path:
       pkgs.runCommand "${path}-manifests" {} ''

--- a/modules/lib/network.nix
+++ b/modules/lib/network.nix
@@ -6,7 +6,7 @@ in
     lib,
     ...
   }: {
-    flake.lib.network = {
+    flake.custom.lib.network = {
       # Helper to get split an IP with CIDR mask and return just the address
       getAddress = ip: head (split "/" ip);
 
@@ -26,7 +26,7 @@ in
       # such as `eth1.100` where it's name and ID
       getVlanList = interfaces:
         map
-        config.flake.lib.network.fixVlanName
+        config.flake.custom.lib.network.fixVlanName
         (lib.filter (lib.hasInfix "-") (attrNames interfaces));
 
       # Template for the VLAN schema I use

--- a/modules/lib/packageLists.nix
+++ b/modules/lib/packageLists.nix
@@ -1,5 +1,5 @@
 {
-  flake.functions.packageLists = {pkgs}: let
+  flake.custom.functions.packageLists = {pkgs}: let
     # Take in a package list (list of strings) and convert to a list of derviations
     # string manipulation is to ensure proper matching of attributes
     makePkgList = pkgList:

--- a/modules/lib/print_config.nix
+++ b/modules/lib/print_config.nix
@@ -1,5 +1,5 @@
 {
-  flake.functions.printConfig = {
+  flake.custom.functions.printConfig = {
     pkgs,
     name,
     cfg,

--- a/modules/lib/wireguard.nix
+++ b/modules/lib/wireguard.nix
@@ -1,5 +1,5 @@
 {lib, ...}: {
-  flake.functions.wireguard = {pkgs}: {
+  flake.custom.functions.wireguard = {pkgs}: {
     genInterface = {
       cfgPath ? config.sops.secrets."wireguard-${name}".path,
       config,

--- a/modules/nixos/graphical/desktop-environments/niri.nix
+++ b/modules/nixos/graphical/desktop-environments/niri.nix
@@ -1,5 +1,5 @@
 {config, ...}: let
-  inherit (config.flake.wrappers) mkNiri;
+  inherit (config.flake.custom.wrappers) mkNiri;
 in {
   flake.modules.nixos.niri = {
     config,

--- a/modules/nixos/graphical/desktop-environments/oxwm.nix
+++ b/modules/nixos/graphical/desktop-environments/oxwm.nix
@@ -5,7 +5,7 @@
     ...
   }: {
     imports = [
-      config.flake.hjemConfigs.oxwm
+      config.flake.custom.hjemConfigs.oxwm
     ];
 
     environment.systemPackages = with pkgs; [

--- a/modules/nixos/network/default.nix
+++ b/modules/nixos/network/default.nix
@@ -4,7 +4,7 @@
 # You have been warned
 {config, ...}: let
   inherit (config.flake) hosts;
-  inherit (config.flake.lib.network) getAddressAttrs;
+  inherit (config.flake.custom.lib.network) getAddressAttrs;
 in {
   flake.modules.nixos.network = {
     config,

--- a/modules/nixos/network/default.nix
+++ b/modules/nixos/network/default.nix
@@ -3,7 +3,7 @@
 # I also DO NOT respect namespaces - Copy at your own risk
 # You have been warned
 {config, ...}: let
-  inherit (config.flake) hosts;
+  inherit (config.flake.custom) hosts;
   inherit (config.flake.custom.lib.network) getAddressAttrs;
 in {
   flake.modules.nixos.network = {

--- a/modules/nixos/network/hosts.nix
+++ b/modules/nixos/network/hosts.nix
@@ -1,5 +1,5 @@
 {config, ...}: let
-  inherit (config.flake) hosts;
+  inherit (config.flake.custom) hosts;
   inherit (config.flake.custom.lib.network) getAddress;
 
   a = host: interface: getAddress hosts.${host}.interfaces.${interface}.ipv4;

--- a/modules/nixos/network/hosts.nix
+++ b/modules/nixos/network/hosts.nix
@@ -1,6 +1,6 @@
 {config, ...}: let
   inherit (config.flake) hosts;
-  inherit (config.flake.lib.network) getAddress;
+  inherit (config.flake.custom.lib.network) getAddress;
 
   a = host: interface: getAddress hosts.${host}.interfaces.${interface}.ipv4;
 in {

--- a/modules/nixos/network/ntp.nix
+++ b/modules/nixos/network/ntp.nix
@@ -1,5 +1,6 @@
 {config, ...}: let
-  inherit (config.flake) hosts lib;
+  inherit (config.flake) hosts;
+  inherit (config.flake.custom) lib;
 in {
   flake.modules.nixos.ntp = {config, ...}: let
     inherit (config.networking) hostName;

--- a/modules/nixos/network/ntp.nix
+++ b/modules/nixos/network/ntp.nix
@@ -1,6 +1,5 @@
 {config, ...}: let
-  inherit (config.flake) hosts;
-  inherit (config.flake.custom) lib;
+  inherit (config.flake.custom) hosts lib;
 in {
   flake.modules.nixos.ntp = {config, ...}: let
     inherit (config.networking) hostName;

--- a/modules/nixos/network/ospf.nix
+++ b/modules/nixos/network/ospf.nix
@@ -1,6 +1,6 @@
 {config, ...}: let
   inherit (config.flake) hosts;
-  inherit (config.flake.lib.network) getAddress;
+  inherit (config.flake.custom.lib.network) getAddress;
 in {
   flake.modules.nixos.ospf = {
     config,

--- a/modules/nixos/packages/default.nix
+++ b/modules/nixos/packages/default.nix
@@ -4,7 +4,8 @@
     functions,
     ...
   }: let
-    inherit (config.flake) packages packageLists;
+    inherit (config.flake) packages;
+    inherit (config.flake.custom) packageLists;
     inherit (functions.packageLists) combinePkgLists;
 
     pkgList = combinePkgLists (with packageLists; [

--- a/modules/nixos/packages/development.nix
+++ b/modules/nixos/packages/development.nix
@@ -2,7 +2,7 @@
 {config, ...}: {
   flake.modules.nixos.packages-development = {functions, ...}: let
     inherit (functions.packageLists) makePkgList;
-    inherit (config.flake.packageLists) development;
+    inherit (config.flake.custom.packageLists) development;
   in {
     environment.systemPackages = makePkgList development;
   };

--- a/modules/nixos/packages/network.nix
+++ b/modules/nixos/packages/network.nix
@@ -1,6 +1,6 @@
 {config, ...}: {
   flake.modules.nixos.packages-network = {functions, ...}: let
-    inherit (config.flake.packageLists) network;
+    inherit (config.flake.custom.packageLists) network;
     inherit (functions.packageLists) makePkgList;
   in {
     environment.systemPackages = makePkgList network;

--- a/modules/nixos/presets/cloud.nix
+++ b/modules/nixos/presets/cloud.nix
@@ -1,6 +1,6 @@
 {config, ...}: let
   inherit (config.flake) modules packageLists;
-  inherit (config.flake.hjemConfigs) nixos root;
+  inherit (config.flake.custom.hjemConfigs) nixos root;
 in {
   flake.modules.nixos.cloudPreset = {
     pkgs,

--- a/modules/nixos/presets/desktop.nix
+++ b/modules/nixos/presets/desktop.nix
@@ -1,6 +1,6 @@
 {config, ...}: let
   inherit (config.flake) modules;
-  inherit (config.flake.hjemConfigs) nixos root extended;
+  inherit (config.flake.custom.hjemConfigs) nixos root extended;
 in {
   flake.modules.nixos.desktopPreset = {
     imports = with modules.nixos; [

--- a/modules/nixos/presets/lab-network.nix
+++ b/modules/nixos/presets/lab-network.nix
@@ -4,7 +4,7 @@
 {config, ...}: let
   inherit (config) flake;
   inherit
-    (config.flake.lib.network)
+    (config.flake.custom.lib.network)
     getAddress
     ;
 in {

--- a/modules/nixos/presets/lab-network.nix
+++ b/modules/nixos/presets/lab-network.nix
@@ -15,7 +15,7 @@ in {
   }: let
     inherit (builtins) attrNames filter listToAttrs;
     inherit (config.networking) hostName;
-    inherit (flake.hosts.${hostName}) interfaces;
+    inherit (flake.custom.hosts.${hostName}) interfaces;
 
     lo = getAddress interfaces.lo.ipv4;
 

--- a/modules/nixos/presets/server.nix
+++ b/modules/nixos/presets/server.nix
@@ -1,6 +1,6 @@
 {config, ...}: let
   inherit (config.flake) modules;
-  inherit (config.flake.hjemConfigs) nixos root;
+  inherit (config.flake.custom.hjemConfigs) nixos root;
 in {
   flake.modules.nixos.serverPreset = {pkgs, ...}: {
     imports = with modules.nixos; [

--- a/modules/nixos/users/shawn/shawn.nix
+++ b/modules/nixos/users/shawn/shawn.nix
@@ -6,7 +6,7 @@ in {
     pkgs,
     ...
   }: let
-    shell = flake.wrappers.mkFish {
+    shell = flake.custom.wrappers.mkFish {
       inherit pkgs;
       env = config.custom.shell.environmentVariables;
     };

--- a/modules/outputs/homeConfigurations.nix
+++ b/modules/outputs/homeConfigurations.nix
@@ -35,9 +35,9 @@
       inherit pkgs;
       extraSpecialArgs = {
         # This intentionally does not collide with `lib`
-        flakeLib = flake.lib;
+        flakeLib = flake.custom.lib;
         # These require pkgs to be passed so collect and do once to get the ready functions
-        functions = mapAttrs (_: v: v {inherit pkgs;}) flake.functions;
+        functions = mapAttrs (_: v: v {inherit pkgs;}) flake.custom.functions;
       };
       inherit modules;
     };

--- a/modules/outputs/nixosConfigurations.nix
+++ b/modules/outputs/nixosConfigurations.nix
@@ -46,9 +46,9 @@
       # My own custom functions are passed via specialArgs
       specialArgs = {
         # This intentionally does not collide with `lib`
-        flakeLib = flake.lib;
+        flakeLib = flake.custom.lib;
         # These require pkgs to be passed so collect and do once to get the ready functions
-        functions = mapAttrs (_: v: v {inherit pkgs;}) flake.functions;
+        functions = mapAttrs (_: v: v {inherit pkgs;}) flake.custom.functions;
       };
       modules = [flake.modules.nixos.${hostname}] ++ modules;
     };

--- a/modules/packageLists/cli.nix
+++ b/modules/packageLists/cli.nix
@@ -1,6 +1,6 @@
 # Common command line utilities I use
 {
-  flake.packageLists.cli = [
+  flake.custom.packageLists.cli = [
     "bat"
     "duf"
     "dust"

--- a/modules/packageLists/development.nix
+++ b/modules/packageLists/development.nix
@@ -1,5 +1,5 @@
 {
-  flake.packageLists.development = [
+  flake.custom.packageLists.development = [
     # Version control tools
     "git"
     "lazygit"

--- a/modules/packageLists/network.nix
+++ b/modules/packageLists/network.nix
@@ -1,5 +1,5 @@
 {
-  flake.packageLists.network = [
+  flake.custom.packageLists.network = [
     # HTTP/Web
     "curl"
     "wget"

--- a/modules/user/bash/bash.nix
+++ b/modules/user/bash/bash.nix
@@ -1,5 +1,5 @@
 {
-  flake.userModules.bash = {
+  flake.custom.userModules.bash = {
     bashrc = ./bashrc;
 
     bashProfile =

--- a/modules/user/nu/nu.nix
+++ b/modules/user/nu/nu.nix
@@ -1,5 +1,5 @@
 {
-  flake.userModules.nu = {
+  flake.custom.userModules.nu = {
     keyScript = ./key_script.nu;
   };
 }

--- a/modules/user/oxwm/oxwm.nix
+++ b/modules/user/oxwm/oxwm.nix
@@ -1,6 +1,6 @@
 {lib, ...}: {
   # Collect and expose the local files but remove the lua extension from the keyname
-  flake.userModules.oxwm =
+  flake.custom.userModules.oxwm =
     lib.mapAttrs'
     (name: _: {
       name = lib.removeSuffix ".lua" name;

--- a/modules/user/shell/aliases.nix
+++ b/modules/user/shell/aliases.nix
@@ -1,5 +1,5 @@
 {
-  flake.userModules.shellAliases = {
+  flake.custom.userModules.shellAliases = {
     basic = {
       aa = "echo (whoami)@(hostname)";
       ll = "ls -la";

--- a/packages/helium/linux.nix
+++ b/packages/helium/linux.nix
@@ -4,10 +4,11 @@
     pkgs,
     system,
     lib,
+    nvfetcher,
     ...
   }: let
     # Preparation definitions on various tooling
-    source = (pkgs.callPackage config.flake.nvfetcher {}).helium;
+    source = (pkgs.callPackage nvfetcher {}).helium;
     contents = pkgs.appimageTools.extract source;
     inherit (source) pname version src;
 

--- a/packages/helium/mac.nix
+++ b/packages/helium/mac.nix
@@ -1,11 +1,12 @@
-{config, ...}: {
+{
   perSystem = {
     pkgs,
     system,
     lib,
+    nvfetcher,
     ...
   }: let
-    source = (pkgs.callPackage config.flake.nvfetcher {}).helium-mac;
+    source = (pkgs.callPackage nvfetcher {}).helium-mac;
   in
     lib.optionalAttrs (lib.hasSuffix system "darwin") {
       packages.helium = pkgs.stdenve.mkDerivation {

--- a/packages/wrapped/fish/_config.nix
+++ b/packages/wrapped/fish/_config.nix
@@ -7,11 +7,11 @@
 }: let
   inherit (pkgs.lib) getExe;
 
-  starshipConfig = flake.wrappers.mkStarshipConfig {
+  starshipConfig = flake.custom.wrappers.mkStarshipConfig {
     inherit pkgs;
     useCharacter = true;
   };
-  gitConfig = flake.wrappers.mkGitConfig {inherit pkgs;};
+  gitConfig = flake.custom.wrappers.mkGitConfig {inherit pkgs;};
 
   aliasCommands = pkgs.lib.concatStringsSep "\n" (
     pkgs.lib.mapAttrsToList (name: value: "    alias ${name}='${value}'") aliases
@@ -49,7 +49,7 @@ in
     ${aliasCommands}
 
     # Dynamically find my signing key
-    ${getExe pkgs.nushell} ${flake.userModules.nu.keyScript}
+    ${getExe pkgs.nushell} ${flake.custom.userModules.nu.keyScript}
 
 
     # Functions (session-scoped to avoid conflicts)

--- a/packages/wrapped/fish/_config.nix
+++ b/packages/wrapped/fish/_config.nix
@@ -6,12 +6,14 @@
   aliases ? {},
 }: let
   inherit (pkgs.lib) getExe;
+  inherit (flake.custom.wrappers) mkStarshipConfig mkGitConfig;
+  inherit (flake.custom.userModules) nu;
 
-  starshipConfig = flake.custom.wrappers.mkStarshipConfig {
+  starshipConfig = mkStarshipConfig {
     inherit pkgs;
     useCharacter = true;
   };
-  gitConfig = flake.custom.wrappers.mkGitConfig {inherit pkgs;};
+  gitConfig = mkGitConfig {inherit pkgs;};
 
   aliasCommands = pkgs.lib.concatStringsSep "\n" (
     pkgs.lib.mapAttrsToList (name: value: "    alias ${name}='${value}'") aliases
@@ -49,7 +51,7 @@ in
     ${aliasCommands}
 
     # Dynamically find my signing key
-    ${getExe pkgs.nushell} ${flake.custom.userModules.nu.keyScript}
+    ${getExe pkgs.nushell} ${nu.keyScript}
 
 
     # Functions (session-scoped to avoid conflicts)

--- a/packages/wrapped/fish/fish.nix
+++ b/packages/wrapped/fish/fish.nix
@@ -9,6 +9,7 @@
   ...
 }: let
   inherit (config) flake;
+  inherit (config.flake.custom.functions) printConfig;
   inherit (config.flake.custom.wrappers) mkFish mkGitSignersFile;
   inherit (config.flake.custom.userModules.shellAliases) basic extra fish;
 in {
@@ -50,7 +51,7 @@ in {
         ;
     };
 
-    print = config.flake.custom.functions.printConfig {
+    print = printConfig {
       inherit cfg pkgs;
       name = "fish-print-config";
     };

--- a/packages/wrapped/fish/fish.nix
+++ b/packages/wrapped/fish/fish.nix
@@ -9,8 +9,8 @@
   ...
 }: let
   inherit (config) flake;
-  inherit (config.flake.wrappers) mkFish mkGitSignersFile;
-  inherit (config.flake.userModules.shellAliases) basic extra fish;
+  inherit (config.flake.custom.wrappers) mkFish mkGitSignersFile;
+  inherit (config.flake.custom.userModules.shellAliases) basic extra fish;
 in {
   perSystem = {
     pkgs,
@@ -31,7 +31,7 @@ in {
       };
     };
   };
-  flake.wrappers.mkFish = {
+  flake.custom.wrappers.mkFish = {
     pkgs,
     env ? {},
     extraConfig ? "",
@@ -50,7 +50,7 @@ in {
         ;
     };
 
-    print = config.flake.functions.printConfig {
+    print = config.flake.custom.functions.printConfig {
       inherit cfg pkgs;
       name = "fish-print-config";
     };

--- a/packages/wrapped/ghostty.nix
+++ b/packages/wrapped/ghostty.nix
@@ -8,7 +8,7 @@
   lib,
   ...
 }: let
-  inherit (config.flake.wrappers) mkGhosttyConfig;
+  inherit (config.flake.custom.wrappers) mkGhosttyConfig;
   cfg = {
     theme = "Niji";
     background = "#000000";
@@ -44,13 +44,13 @@ in {
     };
   in {
     packages = {
-      ghostty = config.flake.wrappers.mkGhostty {
+      ghostty = config.flake.custom.wrappers.mkGhostty {
         inherit pkg pkgs extraConfig;
       };
     };
   };
 
-  flake.wrappers = {
+  flake.custom.wrappers = {
     mkGhosttyConfig = {
       pkgs,
       extraConfig ? {},
@@ -77,7 +77,7 @@ in {
 
       cfg = mkGhosttyConfig {inherit pkgs extraConfig extraBinds;};
 
-      printCfg = config.flake.functions.printConfig {
+      printCfg = config.flake.custom.functions.printConfig {
         inherit cfg pkgs;
         name = "ghostty-print-config";
       };

--- a/packages/wrapped/ghostty.nix
+++ b/packages/wrapped/ghostty.nix
@@ -9,6 +9,7 @@
   ...
 }: let
   inherit (config.flake.custom.wrappers) mkGhosttyConfig;
+  inherit (config.flake.custom.functions) printConfig;
   cfg = {
     theme = "Niji";
     background = "#000000";
@@ -77,7 +78,7 @@ in {
 
       cfg = mkGhosttyConfig {inherit pkgs extraConfig extraBinds;};
 
-      printCfg = config.flake.custom.functions.printConfig {
+      printCfg = printConfig {
         inherit cfg pkgs;
         name = "ghostty-print-config";
       };

--- a/packages/wrapped/git.nix
+++ b/packages/wrapped/git.nix
@@ -12,6 +12,7 @@
   lib,
   ...
 }: let
+  inherit (config.flake.custom.wrappers) mkGit;
   signingKeys = ''
     sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAICVdKrhTH1OxUE/164StP+Iu5sOGcGEmpTyNvarAUn69AAAABHNzaDo=
     sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIDmeP5ouNAD/hWUMq6DsZzLQCtOIh8rvQghX/huztRc8AAAAEXNzaDptaWNoYWVsQHlrNTcz
@@ -52,7 +53,7 @@
   };
 in {
   perSystem = {pkgs, ...}: {
-    packages.git = config.flake.custom.wrappers.mkGit {inherit pkgs;};
+    packages.git = mkGit {inherit pkgs;};
   };
 
   flake.custom.wrappers = {

--- a/packages/wrapped/git.nix
+++ b/packages/wrapped/git.nix
@@ -52,10 +52,10 @@
   };
 in {
   perSystem = {pkgs, ...}: {
-    packages.git = config.flake.wrappers.mkGit {inherit pkgs;};
+    packages.git = config.flake.custom.wrappers.mkGit {inherit pkgs;};
   };
 
-  flake.wrappers = {
+  flake.custom.wrappers = {
     # The fully wrapped package is somewhat limited, as any nix shell
     # will take precedent over your installed config path
     mkGit = {

--- a/packages/wrapped/helix/helix.nix
+++ b/packages/wrapped/helix/helix.nix
@@ -11,14 +11,14 @@
   lib,
   ...
 }: let
-  inherit (config.flake.wrappers) mkHelixConfig mkHelixLanguages;
+  inherit (config.flake.custom.wrappers) mkHelixConfig mkHelixLanguages;
   inherit (lib) importTOML recursiveUpdate;
 in {
   perSystem = {pkgs, ...}: {
-    packages.helix = config.flake.wrappers.mkHelix {inherit pkgs;};
+    packages.helix = config.flake.custom.wrappers.mkHelix {inherit pkgs;};
   };
 
-  flake.wrappers = {
+  flake.custom.wrappers = {
     mkHelixLanguages = {
       pkgs,
       extraLang,
@@ -72,12 +72,12 @@ in {
       langs = mkHelixLanguages {inherit pkgs extraLang;};
       cfg = mkHelixConfig {inherit pkgs extraCfg;};
 
-      printCfg = config.flake.functions.printConfig {
+      printCfg = config.flake.custom.functions.printConfig {
         inherit cfg pkgs;
         name = "hx-print-config";
       };
 
-      printLangs = config.flake.functions.printConfig {
+      printLangs = config.flake.custom.functions.printConfig {
         inherit pkgs;
         name = "hx-print-languages";
         cfg = langs;

--- a/packages/wrapped/helix/helix.nix
+++ b/packages/wrapped/helix/helix.nix
@@ -12,6 +12,7 @@
   ...
 }: let
   inherit (config.flake.custom.wrappers) mkHelixConfig mkHelixLanguages;
+  inherit (config.flake.custom.functions) printConfig;
   inherit (lib) importTOML recursiveUpdate;
 in {
   perSystem = {pkgs, ...}: {
@@ -72,12 +73,12 @@ in {
       langs = mkHelixLanguages {inherit pkgs extraLang;};
       cfg = mkHelixConfig {inherit pkgs extraCfg;};
 
-      printCfg = config.flake.custom.functions.printConfig {
+      printCfg = printConfig {
         inherit cfg pkgs;
         name = "hx-print-config";
       };
 
-      printLangs = config.flake.custom.functions.printConfig {
+      printLangs = printConfig {
         inherit pkgs;
         name = "hx-print-languages";
         cfg = langs;

--- a/packages/wrapped/hyprland/hyprland.nix
+++ b/packages/wrapped/hyprland/hyprland.nix
@@ -6,7 +6,7 @@
 #
 # This is not yet deployed with Systemd, though I will eventually
 {config, ...}: let
-  inherit (config.flake.wrappers) mkHyprland mkHyprlandConfig;
+  inherit (config.flake.custom.wrappers) mkHyprland mkHyprlandConfig;
 in {
   perSystem = {
     pkgs,
@@ -21,7 +21,7 @@ in {
       };
     };
 
-  flake.wrappers = {
+  flake.custom.wrappers = {
     mkHyprlandConfig = {
       pkgs,
       hyprland ? pkgs.hyprland,
@@ -83,7 +83,7 @@ in {
 
       cfg = import ./_config.nix {inherit pkgs hostConfig;};
 
-      printCfg = config.flake.functions.printConfig {
+      printCfg = config.flake.custom.functions.printConfig {
         inherit cfg pkgs;
         name = "hyprland-print-config";
       };

--- a/packages/wrapped/hyprland/hyprland.nix
+++ b/packages/wrapped/hyprland/hyprland.nix
@@ -7,6 +7,7 @@
 # This is not yet deployed with Systemd, though I will eventually
 {config, ...}: let
   inherit (config.flake.custom.wrappers) mkHyprland mkHyprlandConfig;
+  inherit (config.flake.custom.functions) printConfig;
 in {
   perSystem = {
     pkgs,
@@ -83,7 +84,7 @@ in {
 
       cfg = import ./_config.nix {inherit pkgs hostConfig;};
 
-      printCfg = config.flake.custom.functions.printConfig {
+      printCfg = printConfig {
         inherit cfg pkgs;
         name = "hyprland-print-config";
       };

--- a/packages/wrapped/kitty/kitty.nix
+++ b/packages/wrapped/kitty/kitty.nix
@@ -1,19 +1,19 @@
 # Wrapped Kitty comes with my config and the font I normally use with it
 {config, ...}: {
   perSystem = {pkgs, ...}: {
-    packages.kitty = config.flake.wrappers.mkKitty {
+    packages.kitty = config.flake.custom.wrappers.mkKitty {
       inherit pkgs;
     };
   };
 
-  flake.wrappers.mkKitty = {
+  flake.custom.wrappers.mkKitty = {
     pkgs,
     extraConfig ? {},
     extraBinds ? {},
   }: let
     cfg = import ./_config.nix {inherit pkgs extraConfig extraBinds;};
 
-    printCfg = config.flake.functions.printConfig {
+    printCfg = config.flake.custom.functions.printConfig {
       inherit cfg pkgs;
       name = "kitty-print-config";
     };

--- a/packages/wrapped/kitty/kitty.nix
+++ b/packages/wrapped/kitty/kitty.nix
@@ -1,5 +1,7 @@
 # Wrapped Kitty comes with my config and the font I normally use with it
-{config, ...}: {
+{config, ...}: let
+  inherit (config.flake.custom.functions) printConfig;
+in {
   perSystem = {pkgs, ...}: {
     packages.kitty = config.flake.custom.wrappers.mkKitty {
       inherit pkgs;
@@ -13,7 +15,7 @@
   }: let
     cfg = import ./_config.nix {inherit pkgs extraConfig extraBinds;};
 
-    printCfg = config.flake.custom.functions.printConfig {
+    printCfg = printConfig {
       inherit cfg pkgs;
       name = "kitty-print-config";
     };

--- a/packages/wrapped/niri/niri.nix
+++ b/packages/wrapped/niri/niri.nix
@@ -10,7 +10,9 @@
 #
 # I also include other elements of my Niri experience, which is
 # Noctalia and Kitty
-{config, ...}: {
+{config, ...}: let
+  inherit (config.flake.custom.functions) printConfig;
+in {
   perSystem = {
     pkgs,
     lib,
@@ -78,7 +80,7 @@
 
       cfg = import ./_config.nix {inherit pkgs extraConfig systemd spawnNoctalia;};
 
-      print = config.flake.custom.functions.printConfig {
+      print = printConfig {
         inherit cfg pkgs;
         name = "niri-print-config";
       };

--- a/packages/wrapped/niri/niri.nix
+++ b/packages/wrapped/niri/niri.nix
@@ -17,7 +17,7 @@
     system,
     ...
   }: let
-    inherit (config.flake.wrappers) mkNiri;
+    inherit (config.flake.custom.wrappers) mkNiri;
   in
     lib.optionalAttrs (lib.hasSuffix "linux" system) {
       packages = {
@@ -27,12 +27,12 @@
         niri-t14 = mkNiri {
           inherit pkgs;
           systemd = false;
-          extraConfig = config.flake.extraConfigs.t14-niri;
+          extraConfig = config.flake.custom.extraConfigs.t14-niri;
         };
       };
     };
 
-  flake.wrappers = {
+  flake.custom.wrappers = {
     mkNiriConfig = {
       pkgs,
       extraConfig ? "",
@@ -78,7 +78,7 @@
 
       cfg = import ./_config.nix {inherit pkgs extraConfig systemd spawnNoctalia;};
 
-      print = config.flake.functions.printConfig {
+      print = config.flake.custom.functions.printConfig {
         inherit cfg pkgs;
         name = "niri-print-config";
       };

--- a/packages/wrapped/nushell/nushell.nix
+++ b/packages/wrapped/nushell/nushell.nix
@@ -14,6 +14,7 @@
     mkGitSignersFile
     mkStarship
     ;
+  inherit (config.flake.custom.functions) printConfig;
 in {
   perSystem = {
     pkgs,
@@ -115,12 +116,12 @@ in {
       cfg = mkNuConfig {inherit pkgs extraAliases extraConfig;};
       envCfg = mkNuEnvConfig {inherit pkgs env;};
 
-      printCfg = config.flake.custom.functions.printConfig {
+      printCfg = printConfig {
         inherit cfg pkgs;
         name = "nu-print-config";
       };
 
-      printEnv = config.flake.custom.functions.printConfig {
+      printEnv = printConfig {
         inherit pkgs;
         name = "nu-print-env";
         cfg = envCfg;

--- a/packages/wrapped/nushell/nushell.nix
+++ b/packages/wrapped/nushell/nushell.nix
@@ -6,7 +6,7 @@
   ...
 }: let
   inherit
-    (config.flake.wrappers)
+    (config.flake.custom.wrappers)
     mkNushell
     mkNuConfig
     mkNuEnvConfig
@@ -35,13 +35,13 @@ in {
       };
     };
   };
-  flake.wrappers = {
+  flake.custom.wrappers = {
     mkNuConfig = {
       pkgs,
       extraAliases ? {},
       extraConfig ? "",
     }: let
-      inherit (config.flake.userModules.shellAliases) basic nu extra;
+      inherit (config.flake.custom.userModules.shellAliases) basic nu extra;
       mergedAliases = basic // extra // nu // extraAliases;
       aliases = lib.concatStringsSep "\n" (lib.mapAttrsToList (k: v: "alias ${k} = ${v}") mergedAliases);
     in
@@ -50,7 +50,7 @@ in {
         + (builtins.readFile ./starship.nu)
         + (builtins.readFile ./git.nu)
         + ''
-          source ${config.flake.userModules.nu.keyScript}
+          source ${config.flake.custom.userModules.nu.keyScript}
           source $"($nu.cache-dir)/carapace.nu"
         ''
         + extraConfig
@@ -115,12 +115,12 @@ in {
       cfg = mkNuConfig {inherit pkgs extraAliases extraConfig;};
       envCfg = mkNuEnvConfig {inherit pkgs env;};
 
-      printCfg = config.flake.functions.printConfig {
+      printCfg = config.flake.custom.functions.printConfig {
         inherit cfg pkgs;
         name = "nu-print-config";
       };
 
-      printEnv = config.flake.functions.printConfig {
+      printEnv = config.flake.custom.functions.printConfig {
         inherit pkgs;
         name = "nu-print-env";
         cfg = envCfg;

--- a/packages/wrapped/starship/starship.nix
+++ b/packages/wrapped/starship/starship.nix
@@ -5,13 +5,13 @@
 # is not included because it is useless.  Just the good and relevant
 # things have kept.
 {config, ...}: let
-  inherit (config.flake.wrappers) mkStarshipConfig mkStarship;
+  inherit (config.flake.custom.wrappers) mkStarshipConfig mkStarship;
 in {
   perSystem = {pkgs, ...}: {
     packages.starship = mkStarship {inherit pkgs;};
   };
 
-  flake.wrappers = {
+  flake.custom.wrappers = {
     # Expose just the config if I ever wanted it
     mkStarshipConfig = {
       pkgs,
@@ -27,7 +27,7 @@ in {
     }: let
       cfg = mkStarshipConfig {inherit pkgs extraConfig useCharacter;};
 
-      printCfg = config.flake.functions.printConfig {
+      printCfg = config.flake.custom.functions.printConfig {
         inherit cfg pkgs;
         name = "starship-print-config";
       };

--- a/packages/wrapped/starship/starship.nix
+++ b/packages/wrapped/starship/starship.nix
@@ -6,6 +6,7 @@
 # things have kept.
 {config, ...}: let
   inherit (config.flake.custom.wrappers) mkStarshipConfig mkStarship;
+  inherit (config.flake.custom.functions) printConfig;
 in {
   perSystem = {pkgs, ...}: {
     packages.starship = mkStarship {inherit pkgs;};
@@ -27,7 +28,7 @@ in {
     }: let
       cfg = mkStarshipConfig {inherit pkgs extraConfig useCharacter;};
 
-      printCfg = config.flake.custom.functions.printConfig {
+      printCfg = printConfig {
         inherit cfg pkgs;
         name = "starship-print-config";
       };

--- a/packages/wrapped/zed/zed.nix
+++ b/packages/wrapped/zed/zed.nix
@@ -5,7 +5,7 @@
   lib,
   ...
 }: {
-  flake.wrappers.mkZedConfig = {
+  flake.custom.wrappers.mkZedConfig = {
     pkgs,
     extraConfig ? {},
   }:
@@ -83,7 +83,7 @@
     packages =
       {
         zeditor = localPkg;
-        zedConfig = config.flake.wrappers.mkZedConfig {inherit pkgs;};
+        zedConfig = config.flake.custom.wrappers.mkZedConfig {inherit pkgs;};
       }
       // lib.optionalAttrs (lib.hasSuffix "linux" system) {
         zeditor-jailed = jail "zeditor" localPkg bwrapFeatures;

--- a/packages/wrapped/zed/zed.nix
+++ b/packages/wrapped/zed/zed.nix
@@ -4,7 +4,9 @@
   config,
   lib,
   ...
-}: {
+}: let
+  inherit (config.flake.custom.wrappers) mkZedConfig;
+in {
   flake.custom.wrappers.mkZedConfig = {
     pkgs,
     extraConfig ? {},
@@ -83,7 +85,7 @@
     packages =
       {
         zeditor = localPkg;
-        zedConfig = config.flake.custom.wrappers.mkZedConfig {inherit pkgs;};
+        zedConfig = mkZedConfig {inherit pkgs;};
       }
       // lib.optionalAttrs (lib.hasSuffix "linux" system) {
         zeditor-jailed = jail "zeditor" localPkg bwrapFeatures;


### PR DESCRIPTION
Realign flake outputs to not have nearly as many of custom top level flake outputs.  The majority are now nested under `flake.custom` with just the basics remaining such as modules and npins.